### PR TITLE
Replace false negative with true negative on slide 30/lecture 2

### DIFF
--- a/latex/lecture02/dl4nlp2021-lecture02.tex
+++ b/latex/lecture02/dl4nlp2021-lecture02.tex
@@ -748,7 +748,7 @@ Both systems have accuracy 1004/1015 = 0.99
 			\begin{tabular}{l|rr}
 				& Prediction is Q & Prediction is not Q \\ \hline
 				Truth is Q & True positive (\textbf{TP}) & False negative (\textbf{FN}) \\
-				Truth is not Q & False positive (\textbf{FP}) & False negative (\textbf{FN}) 
+				Truth is not Q & False positive (\textbf{FP}) & True negative (\textbf{TN}) 
 			\end{tabular}
 		\end{footnotesize}
 	\end{table}


### PR DESCRIPTION
Replacing _false negative (FN)_ with _true negative (TN)_ on slide 30 in lecture 2.
Seems to be a typo from copying the line above.